### PR TITLE
Fix: catch request errors

### DIFF
--- a/fmslack/cli.py
+++ b/fmslack/cli.py
@@ -124,12 +124,12 @@ def slack_post(slack_webhook_url, name, artist, album, image):
         "icon_url": image
     }
 
-    r = requests.post(slack_webhook_url, data=json.dumps(payload), headers={
+    response = requests.post(slack_webhook_url, data=json.dumps(payload), headers={
         'content-type': 'application/json'
     })
 
-    if not r.status_code == 200:
-        logger.error('Slack returned invalid status code {0}'.format(r.status_code))
+    if not response.status_code == 200:
+        logger.error('Slack returned invalid status code {0}'.format(response.status_code))
 
 
 def query_api(api_url, uri):
@@ -149,13 +149,13 @@ def query_api(api_url, uri):
     """
 
     url = '{0}/tracks/{1}'.format(api_url, uri)
-    r = requests.get(url)
-    if not r.status_code == 200:
-        logger.error('API returned invalid status code {0}'.format(r.status_code))
+    response = requests.get(url)
+    if not response.status_code == 200:
+        logger.error('API returned invalid status code {0}'.format(response.status_code))
         return None
 
     try:
-        return r.json()
+        return response.json()
     except ValueError:
         return None
 

--- a/fmslack/cli.py
+++ b/fmslack/cli.py
@@ -124,9 +124,15 @@ def slack_post(slack_webhook_url, name, artist, album, image):
         "icon_url": image
     }
 
-    response = requests.post(slack_webhook_url, data=json.dumps(payload), headers={
-        'content-type': 'application/json'
-    })
+    try:
+        response = requests.post(
+            slack_webhook_url,
+            data=json.dumps(payload),
+            headers={
+                'content-type': 'application/json'
+            })
+    except requests.exceptions.RequestException as error:
+        logger.error(error)
 
     if not response.status_code == 200:
         logger.error('Slack returned invalid status code {0}'.format(response.status_code))
@@ -149,7 +155,13 @@ def query_api(api_url, uri):
     """
 
     url = '{0}/tracks/{1}'.format(api_url, uri)
-    response = requests.get(url)
+
+    try:
+        response = requests.get(url)
+    except requests.exceptions.RequestException as error:
+        logger.error(error)
+        return None
+
     if not response.status_code == 200:
         logger.error('API returned invalid status code {0}'.format(response.status_code))
         return None

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -7,8 +7,22 @@ Tests for the Slack integration
 
 import mock
 import unittest
+import requests
 
 from fmslack.cli import slack, query_api, slack_post
+
+
+# Example response from FM API
+TRACK_DATA = {
+    'album': {
+        'artists': [{
+            'name': 'artist name',
+        }],
+        'name': 'album name'
+    },
+    'name': 'track name',
+    'image': 'http://albumimage.url'
+}
 
 
 class BaseTestCase(unittest.TestCase):
@@ -36,15 +50,26 @@ class TestQueryApi(BaseTestCase):
         self.requests.get.return_value = get
         response = query_api('http://api.thisissoon.fm', 'spotify_uri')
 
-        self.requests.get.assert_called_once_with('http://api.thisissoon.fm/tracks/spotify_uri')
+        self.requests.get.assert_called_once_with(
+            'http://api.thisissoon.fm/tracks/spotify_uri')
 
-    def test_tracks_request_error(self):
+    def test_tracks_status_error(self):
 
         get = mock.MagicMock(status_code=404)
         self.requests.get.return_value = get
         response = query_api('http://api.thisissoon.fm', 'spotify_uri')
 
-        self.logger.error.assert_called_once_with('API returned invalid status code 404')
+        self.logger.error.assert_called_once_with(
+            'API returned invalid status code 404')
+
+    def test_tracks_request_error(self):
+
+        self.requests.get.side_effect = requests.exceptions.RequestException()
+        self.assertRaises(
+            requests.exceptions.RequestException,
+            query_api,
+            'http://api.thisissoon.fm',
+            'spotify_uri')
 
 
 class TestSlackPost(BaseTestCase):
@@ -53,29 +78,38 @@ class TestSlackPost(BaseTestCase):
 
         post = mock.MagicMock(status_code=200)
         self.requests.post.return_value = post
-        track = {
-            'name': 'track name',
-            'artist': 'artist name',
-            'album': 'album name',
-            'image': 'http://albumimage.url'
-        }
 
-        response = slack_post('http://slack.com', track['name'], track['artist'], track['album'], track['image'])
+        response = slack_post(
+            'http://slack.com',
+            TRACK_DATA['name'],
+            TRACK_DATA['album']['artists'][0]['name'],
+            TRACK_DATA['album']['name'],
+            TRACK_DATA['image'])
 
-        self.requests.post.assert_called_once()
+        assert self.requests.post.call_count == 1
 
-    def test_slack_post_error(self):
+    def test_slack_post_status_error(self):
 
         post = mock.MagicMock(status_code=401)
         self.requests.post.return_value = post
-        track = {
-            'name': 'track name',
-            'artist': 'artist name',
-            'album': 'album name',
-            'image': 'http://albumimage.url'
-        }
 
-        response = slack_post('http://slack.com', track['name'], track['artist'], track['album'], track['image'])
+        response = slack_post(
+            'http://slack.com',
+            TRACK_DATA['name'],
+            TRACK_DATA['album']['artists'][0]['name'],
+            TRACK_DATA['album']['name'],
+            TRACK_DATA['image'])
 
-        self.logger.error.assert_called_once()
+        self.logger.error.assert_called_once_with('Slack returned invalid status code 401')
 
+    def test_slack_post_request_error(self):
+
+        self.requests.post.side_effect = requests.exceptions.RequestException()
+        self.assertRaises(
+            requests.exceptions.RequestException,
+            slack_post,
+            'http://slack.com',
+            TRACK_DATA['name'],
+            TRACK_DATA['album']['artists'][0]['name'],
+            TRACK_DATA['album']['name'],
+            TRACK_DATA['image'])


### PR DESCRIPTION
Catch and log request errors, to fix #2.

`requests.exceptions.RequestException` will catch all request related errors
