### PR TITLE
Fix: Do not verify SSL

### DIFF
--- a/fmslack/cli.py
+++ b/fmslack/cli.py
@@ -135,7 +135,8 @@ def slack_post(slack_webhook_url, name, artists, album, image):
             data=json.dumps(payload),
             headers={
                 'content-type': 'application/json'
-            })
+            },
+            verify=False)
     except requests.exceptions.RequestException as error:
         logger.error(error)
 
@@ -162,7 +163,7 @@ def query_api(api_url, uri):
     url = '{0}/tracks/{1}'.format(api_url, uri)
 
     try:
-        response = requests.get(url)
+        response = requests.get(url, verify=False)
     except requests.exceptions.RequestException as error:
         logger.error(error)
         return None

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -42,7 +42,8 @@ class TestQueryApi(BaseTestCase):
         query_api('http://api.thisissoon.fm', 'uri')
 
         self.requests.get.assert_called_once_with(
-            'http://api.thisissoon.fm/tracks/uri')
+            'http://api.thisissoon.fm/tracks/uri',
+            verify=False)
 
     def test_tracks_status_error(self):
 


### PR DESCRIPTION
Now we have moved to SSL request to the API fail due to SSL verification errors, this PR disables this. This means we don't have to bundle the CRT.
